### PR TITLE
Removed the propar library from the pyproject.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "bronkhorst_propar >= 1.1.1",
-    "propar >= 1.0.2",
     "tomato >= 1.0rc1",
 ]
 classifiers = [


### PR DESCRIPTION
Correction of the pyproject, propar is indeed not needed. 
This is an error I made while writing the pyproject : 

Here is the github of the propar library : 
https://github.com/Schkimansky/Propar

here is what we need
https://github.com/bronkhorst-developer/bronkhorst-propar